### PR TITLE
Migrate to Zig 0.16.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 zig-out/
+zig-pkg/
 .zig-cache/
 /ref-*

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Store the following in database for authentication:
 ### Authentication
 
 ```zig
-const challenge = try passcay.challenge.generate(allocator);
+const challenge = try passcay.challenge.generate(io, allocator);
 // Pass challenge to client-side for authentication
 
 const input = passcay.auth.AuthVerifyInput{

--- a/build.zig
+++ b/build.zig
@@ -4,23 +4,6 @@ const std = @import("std");
 // declaratively construct a build graph that will be executed by an external
 // runner.
 
-/// Helper function to configure OpenSSL
-/// This function just does basic system library linking since we'll use the native OpenSSL
-fn linkWithOpenSSL(_: *std.Build, step: *std.Build.Step.Compile, target: std.Build.ResolvedTarget) void {
-    // Always link with libc
-    step.linkLibC();
-
-    // Link with OpenSSL libraries
-    step.linkSystemLibrary("crypto");
-    step.linkSystemLibrary("ssl");
-
-    // Add special frameworks for macOS
-    if (target.result.os.tag == .macos) {
-        // step.linkFramework("Security");
-        // step.linkFramework("CoreFoundation");
-    }
-}
-
 pub fn build(b: *std.Build) void {
     // Standard target options allows the person running `zig build` to choose
     // what target to build for. Here we do not override the defaults, which
@@ -40,11 +23,33 @@ pub fn build(b: *std.Build) void {
     });
     const zbor_mod = zbor_dep.module("zbor");
 
+    const translate_c = b.addTranslateC(.{
+        .root_source_file = b.path("src/c.h"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Link with OpenSSL dynamically
+    translate_c.linkSystemLibrary("crypto", .{});
+    translate_c.linkSystemLibrary("ssl", .{});
+
+    // Add special frameworks for macOS
+    if (target.result.os.tag == .macos) {
+        // step.linkFramework("Security");
+        // step.linkFramework("CoreFoundation");
+    }
+
     // Create and add the passcay module to the build so it can be referenced as a dependency
     const passcay_mod = b.addModule("passcay", .{
         .root_source_file = b.path("src/public.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{
+                .name = "c",
+                .module = translate_c.createModule(),
+            },
+        },
     });
     passcay_mod.addImport("zbor", zbor_mod);
 
@@ -57,8 +62,6 @@ pub fn build(b: *std.Build) void {
         .root_module = passcay_mod,
     });
 
-    // Link with OpenSSL dynamically
-    linkWithOpenSSL(b, lib, target);
 
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
@@ -72,12 +75,15 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/test_entry.zig"),
             .target = target,
             .optimize = optimize,
+            .imports = &.{
+                .{
+                    .name = "c",
+                    .module = translate_c.createModule(),
+                },
+            },
         }),
     });
     lib_unit_tests.root_module.addImport("zbor", zbor_mod);
-
-    // Link with OpenSSL for tests
-    linkWithOpenSSL(b, lib_unit_tests, target);
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
@@ -37,8 +37,8 @@
     // internet connectivity.
     .dependencies = .{
         .zbor = .{
-            .url = "https://github.com/r4gus/zbor/archive/refs/tags/0.17.2.tar.gz",
-            .hash = "zbor-0.17.0-kr-CoHIkAwCy2WhoS6MgwSvyQsLWzzNy6a7UTHqMPMmO",
+            .url = "git+https://codeberg.org/r4gus/zbor#e96cd55a111bcbd76b1b51e4988a44ead1b0b48e",
+            .hash = "zbor-0.21.1-kr-CoPJ7AwCFwvJhlhfWF-E4qI7rnHF0MM0NwuZ1WOdU",
         },
         // Note: OpenSSL is a system dependency and needs to be installed separately
     },

--- a/src/c.h
+++ b/src/c.h
@@ -1,0 +1,5 @@
+  #include <openssl/ssl.h>
+  #include <openssl/ec.h>
+  #include <openssl/evp.h>
+  #include <openssl/rsa.h>
+  #include <openssl/err.h>

--- a/src/cbor.zig
+++ b/src/cbor.zig
@@ -538,7 +538,7 @@ test "parseAuthData basic functionality" {
     const testing = std.testing;
 
     var auth_data = [_]u8{0} ** 37;
-    std.crypto.random.bytes(auth_data[0..32]); // RP ID hash
+    testing.io.random(auth_data[0..32]); // RP ID hash
     auth_data[32] = 0x01;
 
     auth_data[33] = 0;
@@ -612,7 +612,7 @@ test "parseAuthenticatorData with user verified flag" {
     const testing = std.testing;
 
     var auth_data = [_]u8{0} ** 37; // Minimum length
-    std.crypto.random.bytes(auth_data[0..32]);
+    testing.io.random(auth_data[0..32]);
 
     auth_data[32] = 0x05; // 0x01 | 0x04
 

--- a/src/challenge.zig
+++ b/src/challenge.zig
@@ -1,22 +1,22 @@
 const std = @import("std");
 const base64 = std.base64;
-const crypto = std.crypto;
+const Io = std.Io;
 
 pub const DEFAULT_CHALLENGE_SIZE: usize = 32;
 
 /// Generate a cryptographically secure 32-byte random challenge for WebAuthn operations
 /// Returns base64url-encoded string that can be sent to the client
-pub fn generate(allocator: std.mem.Allocator) ![]const u8 {
-    return generateWithSize(allocator, DEFAULT_CHALLENGE_SIZE);
+pub fn generate(io: Io, allocator: std.mem.Allocator) ![]const u8 {
+    return generateWithSize(io, allocator, DEFAULT_CHALLENGE_SIZE);
 }
 
 /// Generate a challenge with a specific size in bytes
 /// Returns base64url-encoded string that can be sent to the client
-pub fn generateWithSize(allocator: std.mem.Allocator, size: usize) ![]const u8 {
+pub fn generateWithSize(io: Io, allocator: std.mem.Allocator, size: usize) ![]const u8 {
     const random_bytes = try allocator.alloc(u8, size);
     defer allocator.free(random_bytes);
 
-    crypto.random.bytes(random_bytes);
+    io.random(random_bytes);
 
     const encoded_size = base64.url_safe_no_pad.Encoder.calcSize(random_bytes.len);
     const encoded = try allocator.alloc(u8, encoded_size);
@@ -28,7 +28,7 @@ pub fn generateWithSize(allocator: std.mem.Allocator, size: usize) ![]const u8 {
 
 test "fixed 32-byte challenge generation" {
     const allocator = std.testing.allocator;
-    const challenge2 = try generate(allocator);
+    const challenge2 = try generate(std.testing.io, allocator);
     defer allocator.free(challenge2);
     try std.testing.expectEqual(@as(usize, 43), challenge2.len);
 }
@@ -36,11 +36,11 @@ test "fixed 32-byte challenge generation" {
 test "variable size challenge generation" {
     const allocator = std.testing.allocator;
 
-    const challenge = try generate(allocator);
+    const challenge = try generate(std.testing.io, allocator);
     defer allocator.free(challenge);
     try std.testing.expectEqual(@as(usize, 43), challenge.len);
 
-    const challenge_64 = try generateWithSize(allocator, 64);
+    const challenge_64 = try generateWithSize(std.testing.io, allocator, 64);
     defer allocator.free(challenge_64);
 
     // Calculate the expected size correctly based on the Base64 encoding

--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -15,13 +15,7 @@ const passcay = @import("root.zig");
 const types = passcay.types;
 const util = passcay.util;
 
-const c = @cImport({
-    @cInclude("openssl/ssl.h");
-    @cInclude("openssl/ec.h");
-    @cInclude("openssl/evp.h");
-    @cInclude("openssl/rsa.h");
-    @cInclude("openssl/err.h");
-});
+const c = @import("c");
 
 /// Initialize OpenSSL libraries - must be called before any crypto operations
 pub fn initOpenSSL() !void {

--- a/src/register.zig
+++ b/src/register.zig
@@ -216,7 +216,7 @@ test "verify client data type mismatch" {
     const client_data_json = "{\"type\":\"webauthn.get\",\"challenge\":\"test_challenge\",\"origin\":\"https://example.com\"}";
     const attestation_obj = try allocator.alloc(u8, 256);
     defer allocator.free(attestation_obj);
-    std.crypto.random.bytes(attestation_obj);
+    std.Io.random(testing.io, attestation_obj);
 
     const attestation_obj_b64 = try passcay.util.encodeBase64Url(allocator, attestation_obj);
     defer allocator.free(attestation_obj_b64);
@@ -243,7 +243,7 @@ test "verify challenge mismatch" {
     const client_data_json = "{\"type\":\"webauthn.create\",\"challenge\":\"test_challenge\",\"origin\":\"https://example.com\"}";
     const attestation_obj = try allocator.alloc(u8, 256);
     defer allocator.free(attestation_obj);
-    std.crypto.random.bytes(attestation_obj);
+    std.Io.random(testing.io, attestation_obj);
 
     const attestation_obj_b64 = try passcay.util.encodeBase64Url(allocator, attestation_obj);
     defer allocator.free(attestation_obj_b64);
@@ -270,7 +270,7 @@ test "verify origin mismatch" {
     const client_data_json = "{\"type\":\"webauthn.create\",\"challenge\":\"test_challenge\",\"origin\":\"https://example.com\"}";
     const attestation_obj = try allocator.alloc(u8, 256);
     defer allocator.free(attestation_obj);
-    std.crypto.random.bytes(attestation_obj);
+    std.Io.random(testing.io, attestation_obj);
 
     const attestation_obj_b64 = try passcay.util.encodeBase64Url(allocator, attestation_obj);
     defer allocator.free(attestation_obj_b64);


### PR DESCRIPTION
Here is my migration to Zig 0.16.0 of your project if you are interested.

There are 2 main impacts of the migration:
  - As new developments of r4gus/zbor moved to Codeberg, this changes the dependency to get the latest version compatible with Zig 0.16.0
  - the binding to OpenSSL are now done at build time via `translate_c` (`@cImport` has been removed)